### PR TITLE
Unable to set port value

### DIFF
--- a/the-graph-port/the-graph-port.html
+++ b/the-graph-port/the-graph-port.html
@@ -103,11 +103,14 @@
           var processName = process.getAttribute('name');
           var connection = null;
           graph.edges.forEach(function (edge) {
-            if (edge.target === processName + '.' + this.name) {
-              connection = edge;
-            }
-            if (edge.source === processName + '.' + this.name) {
-              connection = edge;
+            if (!this.isOutport()) {
+              if (edge.target === processName + '.' + this.name) {
+                connection = edge;
+              }
+            } else {
+              if (edge.source === processName + '.' + this.name) {
+                connection = edge;
+              }
             }
           }.bind(this));
           return connection;


### PR DESCRIPTION
I think I'm hitting a fairly trivial bug to fix.
I have a component with xdiv,ydiv input port names that also happens to have xdiv,ydiv output port names. The UI prevents me to set a value on these input ports, even though they're not connected.

While trying to debug the issue, a quick console.log() in noflo-node-inspector.html shows that the ports are set readonly because they're connected, but they aren't. The output ports with identical names are though. I think the function getInports must be reporting the wrong ports.
