### PR TITLE
Fixes autolayout partially

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "polymer": "~0.2.0",
     "font-awesome": "~4.0.3",
     "react": "~0.9.0",
-    "klay-js": "~0.0.4"
+    "klay-js": "~0.0.5"
   },
   "license": "MIT",
   "ignore": [

--- a/the-graph/noflo-klay-interface.js
+++ b/the-graph/noflo-klay-interface.js
@@ -3,7 +3,7 @@ function klayinit () {
 
   Array.prototype.clean = function() {
     for (var i = 0; i < this.length; i++) {
-      if (this[i] === null || this[i] === undefined) {         
+      if (this[i] === null || this[i] === undefined) {
         this.splice(i, 1);
         i--;
       }
@@ -255,7 +255,7 @@ function klayinit () {
     
     // Convert the NoFlo graph to KGraph
     var kGraph = toKieler(graph, portInfo, direction);
-
+   
     $klay.layout({
       graph: kGraph,
       options: options,


### PR DESCRIPTION
Still doesn't work for Chrome Apps and the double-click to get autolayout button working persists. Besides that, it is currently working for graphs with groups, ports and forces i/o nodes to stay in the first/last layers.
