### PR TITLE
FIXED_RATIO for portConstraints on autolayout

### DIFF
--- a/the-graph/noflo-klay-interface.js
+++ b/the-graph/noflo-klay-interface.js
@@ -73,7 +73,7 @@ function klayinit () {
         height: nodeProperties.height,
         ports: inPortsTemp.concat(outPortsTemp),
         properties: {
-          'portConstraints': 'FREE'
+          'portConstraints': 'FIXED_RATIO'
         }
       };
       idx[node.id] = countIdx++;
@@ -103,7 +103,7 @@ function klayinit () {
         height: nodeProperties.height,
         ports: [uniquePort],
         properties: {
-          'portConstraints': 'FREE',
+          'portConstraints': 'FIXED_RATIO',
           "de.cau.cs.kieler.klay.layered.layerConstraint": "FIRST_SEPARATE"
         }
       };
@@ -132,7 +132,7 @@ function klayinit () {
         height: nodeProperties.height,
         ports: [uniquePort],
         properties: {
-          'portConstraints': 'FREE',
+          'portConstraints': 'FIXED_RATIO',
           "de.cau.cs.kieler.klay.layered.layerConstraint": "LAST_SEPARATE"
         }
       };


### PR DESCRIPTION
I've experimented the available `portConstraints`.

FIXED_POS
![fixed_pos](https://f.cloud.github.com/assets/49062/2354829/3bd181ba-a5cc-11e3-8dda-fa48d100c018.png)

FIXED_ORDER
![fixed_order](https://f.cloud.github.com/assets/49062/2354832/483188ba-a5cc-11e3-9e91-84f1086b85e8.png)

FIXED_SIDE
![fixed_side](https://f.cloud.github.com/assets/49062/2354837/5533a8ea-a5cc-11e3-9427-1e488223218f.png)

FREE
![free](https://f.cloud.github.com/assets/49062/2354839/642e23f2-a5cc-11e3-9998-5702d0783cc5.png)

FIXED_RATIO
![fixed_ratio](https://f.cloud.github.com/assets/49062/2354841/6e5a60b6-a5cc-11e3-9873-282300c3263a.png)

I don't know if that's true just for this particular graph but FIXED_RATIO seems more "gridy" and with minor edge crossing. We certainly should test other graphs.
