### PR TITLE
group nodes metadata changes

### DIFF
--- a/the-graph/the-graph-graph.js
+++ b/the-graph/the-graph-graph.js
@@ -96,8 +96,6 @@
     moveGroup: function (nodes, dx, dy) {
       var graph = this.state.graph;
 
-      graph.startTransaction('movegroup');
-
       // Move each group member
       var len = nodes.length;
       for (var i=0; i<len; i++) {
@@ -118,8 +116,6 @@
           });
         }
       }
-
-      graph.endTransaction('movegroup');
     },
     getComponentInfo: function (componentName) {
       return this.props.library[componentName];

--- a/the-graph/the-graph-group.js
+++ b/the-graph/the-graph-group.js
@@ -78,6 +78,8 @@
         label.addEventListener("track", this.onTrack);
         label.addEventListener("trackend", this.onTrackEnd);
       }
+
+      this.props.graph.startTransaction('movegroup');
     },
     onTrack: function (event) {
       // Don't fire on graph
@@ -107,6 +109,8 @@
         label.removeEventListener("track", this.onTrack);
         label.removeEventListener("trackend", this.onTrackEnd);
       }
+
+      this.props.graph.endTransaction('movegroup');
     },
     componentDidUpdate: function (prevProps, prevState) {
       // HACK to change SVG class https://github.com/facebook/react/issues/1139


### PR DESCRIPTION
When moving groups, we need to batch the sequence of move event for all the nodes on the canvas rather than batching only grouped items per event.
