### PR TITLE
editor: add focusNode() method

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,8 @@
     "hammerjs": "~1.1.2",
     "font-awesome": "~4.1.0",
     "react": "~0.11.1",
-    "klay-js": "~0.1.0"
+    "klay-js": "~0.1.0",
+    "react.animate-djdeath": "0.0.3"
   },
   "license": "MIT",
   "ignore": [

--- a/the-graph-editor/index.html
+++ b/the-graph-editor/index.html
@@ -6,13 +6,15 @@
 
     <!-- Bower Libraries -->
     <script src="../bower_components/platform/platform.js"></script>
-    <script src="../bower_components/react/react.js"></script>
+    <script src="../bower_components/react/react-with-addons.js"></script>
     <script src="../bower_components/klay-js/klay.js"></script>
     <script src="../bower_components/hammerjs/hammer.min.js"></script>
+    <script src="../bower_components/ease-djdeath/index.js"></script>
+    <script src="../bower_components/react.animate-djdeath/react.animate.js"></script>
 
     <!-- Browserify Libraries -->
     <script src="../build/noflo.js"></script>
-    
+
     <!-- Custom elements -->
     <link rel="import" href="../bower_components/polymer/polymer.html">
     <!-- <link rel="import" href="../bower_components/polymer-gestures/polymer-gestures.html"> -->

--- a/the-graph-editor/the-graph-editor.html
+++ b/the-graph-editor/the-graph-editor.html
@@ -350,6 +350,9 @@
       updateErrorNodes: function () {
         this.$.graph.errorNodesChanged();
       },
+      focusNode: function (node) {
+        this.$.graph.focusNode(node);
+      },
       getComponent: function (name) {
         return this.$.graph.getComponent(name);
       },

--- a/the-graph/the-graph.html
+++ b/the-graph/the-graph.html
@@ -346,6 +346,9 @@
           forceSelection: this.forceSelection
         });
       },
+      focusNode: function (node) {
+        this.appView.focusNode(node);
+      },
       menusChanged: function () {
         // Only if the object itself changes, 
         // otherwise builds menu from reference every time menu shown

--- a/the-graph/the-graph.js
+++ b/the-graph/the-graph.js
@@ -183,6 +183,75 @@
     };
   };
 
+  TheGraph.findAreaFit = function (point1, point2, width, height) {
+    var limits = {
+      minX: point1.x < point2.x ? point1.x : point2.x,
+      minY: point1.y < point2.y ? point1.y : point2.y,
+      maxX: point1.x > point2.x ? point1.x : point2.x,
+      maxY: point1.y > point2.y ? point1.y : point2.y
+    };
+
+    limits.minX -= TheGraph.config.nodeSize;
+    limits.minY -= TheGraph.config.nodeSize;
+    limits.maxX += TheGraph.config.nodeSize * 2;
+    limits.maxY += TheGraph.config.nodeSize * 2;
+
+    var gWidth = limits.maxX - limits.minX;
+    var gHeight = limits.maxY - limits.minY;
+
+    var scaleX = width / gWidth;
+    var scaleY = height / gHeight;
+
+    var scale, x, y;
+    if (scaleX < scaleY) {
+      scale = scaleX;
+      x = 0 - limits.minX * scale;
+      y = 0 - limits.minY * scale + (height-(gHeight*scale))/2;
+    } else {
+      scale = scaleY;
+      x = 0 - limits.minX * scale + (width-(gWidth*scale))/2;
+      y = 0 - limits.minY * scale;
+    }
+
+    return {
+      x: x,
+      y: y,
+      scale: scale
+    };
+  };
+
+  TheGraph.findNodeFit = function (node, width, height) {
+    var limits = {
+      minX: node.metadata.x - TheGraph.config.nodeSize,
+      minY: node.metadata.y - TheGraph.config.nodeSize,
+      maxX: node.metadata.x + TheGraph.config.nodeSize * 2,
+      maxY: node.metadata.y + TheGraph.config.nodeSize * 2
+    };
+
+    var gWidth = limits.maxX - limits.minX;
+    var gHeight = limits.maxY - limits.minY;
+
+    var scaleX = width / gWidth;
+    var scaleY = height / gHeight;
+
+    var scale, x, y;
+    if (scaleX < scaleY) {
+      scale = scaleX;
+      x = 0 - limits.minX * scale;
+      y = 0 - limits.minY * scale + (height-(gHeight*scale))/2;
+    } else {
+      scale = scaleY;
+      x = 0 - limits.minX * scale + (width-(gWidth*scale))/2;
+      y = 0 - limits.minY * scale;
+    }
+
+    return {
+      x: x,
+      y: y,
+      scale: scale
+    };
+  };
+
   // SVG arc math
   var angleToX = function (percent, radius) {
     return radius * Math.cos(2*Math.PI * percent);


### PR DESCRIPTION
This adds Google Maps like animation on focus of a given node.

https://www.youtube.com/watch?v=4rrQGZsGCK0

Not so happy with the react.animate dependency.
Given the fixes I had to make, I wonder how this ever worked for anybody : 

https://github.com/pleasetrythisathome/react.animate/commit/7d77b0de2bf680882ccb867c839740a3785070da
https://github.com/pleasetrythisathome/react.animate/commit/340b1f90243d8b7c8a4db8c9c8b90c705b23c818
https://github.com/pleasetrythisathome/react.animate/commit/8d1b97d4b0d578c7cd65bc072f5647a119a57fcf

Oh well... YOLO they say...
