### PR TITLE
Add dependencies to NPM

### DIFF
--- a/examples/demo-full.html
+++ b/examples/demo-full.html
@@ -8,7 +8,7 @@
     <script src="../node_modules/webcomponents.js/webcomponents.js"></script>
     <script src="../node_modules/react/dist/react.js"></script>
     <script src="../node_modules/react-dom/dist/react-dom.js"></script>
-    <script src="../bower_components/klayjs-noflo/klay-noflo.js"></script>
+    <script src="../node_modules/klayjs-noflo/klay-noflo.js"></script>
     <script src="../node_modules/hammerjs/hammer.min.js"></script>
     <script src="../bower_components/ease-djdeath/index.js"></script>
     <script src="../bower_components/react.animate-djdeath/react.animate.js"></script>

--- a/examples/demo-full.html
+++ b/examples/demo-full.html
@@ -22,16 +22,16 @@
     <link rel="import" href="../the-graph-nav/the-graph-nav.html">
 
     <!-- Fonts -->
-    <link rel="stylesheet" href="../bower_components/font-awesome/css/font-awesome.min.css">
+    <link rel="stylesheet" href="../node_modules/font-awesome/css/font-awesome.min.css">
     <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro:400' rel='stylesheet' type='text/css'>
     <style>
       @font-face {
         /* we want the svg version */
         font-family: 'FontAwesomeSVG';
-        src: url('../bower_components/font-awesome/fonts/fontawesome-webfont.svg?v=4.0.3#fontawesomeregular') format('svg'),
-          url('../bower_components/font-awesome/fonts/fontawesome-webfont.eot?#iefix&v=4.0.3') format('embedded-opentype'), 
-          url('../bower_components/font-awesome/fonts/fontawesome-webfont.woff?v=4.0.3') format('woff'), 
-          url('../bower_components/font-awesome/fonts/fontawesome-webfont.ttf?v=4.0.3') format('truetype');
+        src: url('../node_modules/font-awesome/fonts/fontawesome-webfont.svg?v=4.0.3#fontawesomeregular') format('svg'),
+          url('../node_modules/font-awesome/fonts/fontawesome-webfont.eot?#iefix&v=4.0.3') format('embedded-opentype'), 
+          url('../node_modules/font-awesome/fonts/fontawesome-webfont.woff?v=4.0.3') format('woff'), 
+          url('../node_modules/font-awesome/fonts/fontawesome-webfont.ttf?v=4.0.3') format('truetype');
         font-weight: normal;
         font-style: normal;
       }

--- a/examples/demo-full.html
+++ b/examples/demo-full.html
@@ -4,10 +4,10 @@
     <title>Graph Editor</title>
     <meta charset="utf-8">
 
-    <!-- Bower Libraries -->
-    <script src="../bower_components/webcomponentsjs/webcomponents.js"></script>
-    <script src="../bower_components/react/react-with-addons.js"></script>
-    <script src="../bower_components/react/react-dom.js"></script>
+    <!-- Libraries -->
+    <script src="../node_modules/webcomponents.js/webcomponents.js"></script>
+    <script src="../node_modules/react/dist/react.js"></script>
+    <script src="../node_modules/react-dom/dist/react-dom.js"></script>
     <script src="../bower_components/klayjs-noflo/klay-noflo.js"></script>
     <script src="../bower_components/hammerjs/hammer.min.js"></script>
     <script src="../bower_components/ease-djdeath/index.js"></script>

--- a/examples/demo-full.html
+++ b/examples/demo-full.html
@@ -9,7 +9,7 @@
     <script src="../node_modules/react/dist/react.js"></script>
     <script src="../node_modules/react-dom/dist/react-dom.js"></script>
     <script src="../bower_components/klayjs-noflo/klay-noflo.js"></script>
-    <script src="../bower_components/hammerjs/hammer.min.js"></script>
+    <script src="../node_modules/hammerjs/hammer.min.js"></script>
     <script src="../bower_components/ease-djdeath/index.js"></script>
     <script src="../bower_components/react.animate-djdeath/react.animate.js"></script>
 

--- a/examples/demo-simple.html
+++ b/examples/demo-simple.html
@@ -22,16 +22,16 @@
     <link rel="import" href="../the-graph-nav/the-graph-nav.html">
 
     <!-- Fonts -->
-    <link rel="stylesheet" href="../bower_components/font-awesome/css/font-awesome.min.css">
+    <link rel="stylesheet" href="../node_modules/font-awesome/css/font-awesome.min.css">
     <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro:400' rel='stylesheet' type='text/css'>
     <style>
       @font-face {
         /* we want the svg version */
         font-family: 'FontAwesomeSVG';
-        src: url('../bower_components/font-awesome/fonts/fontawesome-webfont.svg?v=4.0.3#fontawesomeregular') format('svg'),
-          url('../bower_components/font-awesome/fonts/fontawesome-webfont.eot?#iefix&v=4.0.3') format('embedded-opentype'),
-          url('../bower_components/font-awesome/fonts/fontawesome-webfont.woff?v=4.0.3') format('woff'),
-          url('../bower_components/font-awesome/fonts/fontawesome-webfont.ttf?v=4.0.3') format('truetype');
+        src: url('../node_modules/font-awesome/fonts/fontawesome-webfont.svg?v=4.0.3#fontawesomeregular') format('svg'),
+          url('../node_modules/font-awesome/fonts/fontawesome-webfont.eot?#iefix&v=4.0.3') format('embedded-opentype'),
+          url('../node_modules/font-awesome/fonts/fontawesome-webfont.woff?v=4.0.3') format('woff'),
+          url('../node_modules/font-awesome/fonts/fontawesome-webfont.ttf?v=4.0.3') format('truetype');
         font-weight: normal;
         font-style: normal;
       }

--- a/examples/demo-simple.html
+++ b/examples/demo-simple.html
@@ -4,10 +4,10 @@
     <title>Graph Editor Demo</title>
     <meta charset="utf-8">
 
-    <!-- Bower Libraries -->
-    <script src="../bower_components/webcomponentsjs/webcomponents.js"></script>
-    <script src="../bower_components/react/react-with-addons.js"></script>
-    <script src="../bower_components/react/react-dom.js"></script>
+    <!-- Libraries -->
+    <script src="../node_modules/webcomponents.js/webcomponents.js"></script>
+    <script src="../node_modules/react/dist/react.js"></script>
+    <script src="../node_modules/react-dom/dist/react-dom.js"></script>
     <script src="../bower_components/klayjs-noflo/klay-noflo.js"></script>
     <script src="../bower_components/hammerjs/hammer.min.js"></script>
     <script src="../bower_components/ease-djdeath/index.js"></script>

--- a/examples/demo-simple.html
+++ b/examples/demo-simple.html
@@ -8,7 +8,7 @@
     <script src="../node_modules/webcomponents.js/webcomponents.js"></script>
     <script src="../node_modules/react/dist/react.js"></script>
     <script src="../node_modules/react-dom/dist/react-dom.js"></script>
-    <script src="../bower_components/klayjs-noflo/klay-noflo.js"></script>
+    <script src="../node_modules/klayjs-noflo/klay-noflo.js"></script>
     <script src="../node_modules/hammerjs/hammer.min.js"></script>
     <script src="../bower_components/ease-djdeath/index.js"></script>
     <script src="../bower_components/react.animate-djdeath/react.animate.js"></script>

--- a/examples/demo-simple.html
+++ b/examples/demo-simple.html
@@ -9,7 +9,7 @@
     <script src="../node_modules/react/dist/react.js"></script>
     <script src="../node_modules/react-dom/dist/react-dom.js"></script>
     <script src="../bower_components/klayjs-noflo/klay-noflo.js"></script>
-    <script src="../bower_components/hammerjs/hammer.min.js"></script>
+    <script src="../node_modules/hammerjs/hammer.min.js"></script>
     <script src="../bower_components/ease-djdeath/index.js"></script>
     <script src="../bower_components/react.animate-djdeath/react.animate.js"></script>
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
   "main": "the-graph-editor/index.html",
   "dependencies": {
     "fbp-graph": "^0.1.0",
-    "tv4": "^1.2.7"
+    "react": "^0.14.3",
+    "react-dom": "^0.14.3",
+    "tv4": "^1.2.7",
+    "webcomponents.js": "^0.6.0"
   },
   "devDependencies": {
     "bower": "^1.7.9",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "main": "the-graph-editor/index.html",
   "dependencies": {
     "fbp-graph": "^0.1.0",
+    "hammerjs": "^2.0.8",
     "react": "^0.14.3",
     "react-dom": "^0.14.3",
     "tv4": "^1.2.7",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "fbp-graph": "^0.1.0",
     "hammerjs": "^2.0.8",
+    "klayjs-noflo": "^0.3.1",
     "react": "^0.14.3",
     "react-dom": "^0.14.3",
     "tv4": "^1.2.7",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "main": "the-graph-editor/index.html",
   "dependencies": {
     "fbp-graph": "^0.1.0",
+    "font-awesome": "^4.6.3",
     "hammerjs": "^2.0.8",
     "klayjs-noflo": "^0.3.1",
     "react": "^0.14.3",

--- a/scripts/build-font-awesome-javascript.js
+++ b/scripts/build-font-awesome-javascript.js
@@ -39,4 +39,4 @@ var generateFile = function (err, data) {
   });
 };
 
-fs.readFile( __dirname+'/../bower_components/font-awesome/less/variables.less', 'utf8', generateFile );
+fs.readFile( __dirname+'/../node_modules/font-awesome/less/variables.less', 'utf8', generateFile );

--- a/the-graph/the-graph-app.js
+++ b/the-graph/the-graph-app.js
@@ -63,9 +63,14 @@
     return TheGraph.ModalBG(options);
   }
 
+  var mixins = [];
+  if (window.React.Animate) {
+    mixins.push(React.Animate);
+  }
+
   TheGraph.App = React.createFactory( React.createClass({
     displayName: "TheGraphApp",
-    mixins: [React.Animate],
+    mixins: mixins,
     getInitialState: function() {
       // Autofit
       var fit = TheGraph.findFit(this.props.graph, this.props.width, this.props.height);
@@ -278,6 +283,12 @@
       var scale_ratio_1 = Math.abs(graphfit.scale - this.state.scale);
       var scale_ratio_2 = Math.abs(fit.scale - graphfit.scale);
       var scale_ratio_diff = scale_ratio_1 + scale_ratio_2;
+
+      // Animation not available, jump right there
+      if (!this.animate) {
+        this.setState({ x: fit.x, y: fit.y, scale: fit.scale });
+        return;
+      }
 
       // Animate zoom-out then zoom-in
       this.animate({

--- a/the-graph/the-graph.html
+++ b/the-graph/the-graph.html
@@ -60,7 +60,7 @@
         // Initializes the autolayouter
         this.autolayouter = klayNoflo.init({
           onSuccess: this.applyAutolayout.bind(this),
-          workerScript: "../bower_components/klayjs/klay.js"
+          workerScript: "../node_modules/klayjs/klay.js"
         });
       },
       ready: function () {

--- a/themes/default/the-graph.styl
+++ b/themes/default/the-graph.styl
@@ -1,14 +1,3 @@
-/* Need to add this to the .html with correct paths to get the svg version
-@font-face {
-  font-family: 'FontAwesomeSVG';
-  src: url('../bower_components/font-awesome/fonts/fontawesome-webfont.svg?v=4.0.3#fontawesomeregular') format('svg'),
-    url('../bower_components/font-awesome/fonts/fontawesome-webfont.eot?#iefix&v=4.0.3') format('embedded-opentype'), 
-    url('../bower_components/font-awesome/fonts/fontawesome-webfont.woff?v=4.0.3') format('woff'), 
-    url('../bower_components/font-awesome/fonts/fontawesome-webfont.ttf?v=4.0.3') format('truetype');
-  font-weight: normal;
-  font-style: normal;
-}
-*/
 
 .the-graph-app {
   background-color: var-bg;


### PR DESCRIPTION
And use node_modules where-ever possible. Not dropping Bower support yet.

Should now be able to use NPM for everything, except for:

* Polymer #222  
* React.Animate for focusNode animation #318