### PR TITLE
Binds editor instead of getDefaultMenus.

### DIFF
--- a/the-graph-editor/the-graph-editor.js
+++ b/the-graph-editor/the-graph-editor.js
@@ -43,7 +43,7 @@ function getDefaultMenus(editor) {
         }
       }
       this.selectedEdges = newSelection;
-    }.bind(this)
+    }.bind(editor)
   };
 
   var menus = {


### PR DESCRIPTION
This fixes js errors.