### PR TITLE
Update to React 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "hammerjs": "^2.0.8",
     "klayjs-noflo": "^0.3.1",
     "react": "^15.5.4",
-    "react-dom": "^0.14.3",
+    "react-dom": "^15.5.4",
     "tv4": "^1.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "font-awesome": "^4.6.3",
     "hammerjs": "^2.0.8",
     "klayjs-noflo": "^0.3.1",
-    "react": "^0.14.3",
+    "react": "^15.5.4",
     "react-dom": "^0.14.3",
     "tv4": "^1.3.0"
   },


### PR DESCRIPTION
It _seems_ the-graph runs without modifications with React 15.

Only warning I'm seeing is:

> Warning: TheGraphGraph: isMounted is deprecated. Instead, make sure to clean up subscriptions and pending requests in componentWillUnmount to prevent memory leaks.

Fixes #370 
