### PR TITLE
React 15 / Jest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 /dist
 npm-debug.log
 /spec/*.js
+/coverage

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,6 +18,7 @@
       'react',
       'react-dom',
       'create-react-class',
+      'hammerjs',
       '@pleasetrythisathome/react.animate'
     ];
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -17,6 +17,7 @@
     var externals = [
       'react',
       'react-dom',
+      'create-react-class',
       '@pleasetrythisathome/react.animate'
     ];
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,6 +14,12 @@
       tests: ['spec/*.coffee', 'spec/runner.html']
     };
 
+    var externals = [
+      'react',
+      'react-dom',
+      '@pleasetrythisathome/react.animate'
+    ];
+
     var glob = require('glob');
     var stylExpand = glob.sync('./themes/*.styl').join(' ');
 
@@ -40,11 +46,20 @@
         }
       },
       browserify: {
+        vendor: {
+          files: {
+            'dist/vendor.js': ['spec/vendor.js'],
+          },
+          options: {
+            require: externals
+          }
+        },
         libs: {
           files: {
             'dist/the-graph.js': ['index.js'],
           },
           options: {
+            external: externals,
             transform: ['coffeeify'],
             browserifyOptions: {
               standalone: 'TheGraph'
@@ -134,7 +149,7 @@
     this.loadNpmTasks('grunt-saucelabs');
 
     this.registerTask('dev', ['test', 'watch']);
-    this.registerTask('build', ['exec:build_stylus', 'exec:build_fa', 'browserify:libs']);
+    this.registerTask('build', ['exec:build_stylus', 'exec:build_fa', 'browserify:libs', 'browserify:vendor']);
     this.registerTask('test', ['jshint:all', 'build', 'coffee', 'connect:server']);
     this.registerTask('crossbrowser', ['test', 'saucelabs-mocha']);
     this.registerTask('default', ['test']);

--- a/__tests__/basics.js
+++ b/__tests__/basics.js
@@ -1,0 +1,55 @@
+const { render } = require("enzyme");
+const fbpGraph = require("fbp-graph");
+const TheGraph = require("../index.js");
+
+const parseFBP = fbpString =>
+  new Promise((resolve, reject) =>
+    fbpGraph.graph.loadFBP(
+      fbpString,
+      (err, graph) =>
+        err instanceof fbpGraph.Graph
+          ? resolve(err)
+          : err ? reject(err) : resolve(graph)
+    )
+  );
+
+const dummyComponent = {
+  inports: [
+    {
+      name: "in",
+      type: "all"
+    }
+  ],
+  outports: [
+    {
+      name: "out",
+      type: "all"
+    }
+  ]
+};
+
+const name = "'42' -> CONFIG foo(Foo) OUT -> IN bar(Bar)";
+const library = { Foo: dummyComponent, Bar: dummyComponent };
+
+describe("Basics", function() {
+  describe("loading a simple graph", function() {
+    let rendered;
+
+    beforeAll(async () => {
+      const graph = await parseFBP(name);
+      rendered = render(TheGraph.App({ graph, library }));
+    });
+
+    it("should render 2 nodes", () => {
+      expect(rendered.find(".node")).toHaveLength(2);
+    });
+
+    it("should render 1 edge", () => {
+      expect(rendered.find(".edge")).toHaveLength(1);
+    });
+
+    it("should render 1 IIP", () => {
+      expect(rendered.find(".iip")).toHaveLength(1);
+    });
+  });
+});

--- a/__tests__/editing.js
+++ b/__tests__/editing.js
@@ -1,0 +1,314 @@
+const { mount } = require("enzyme");
+const fbpGraph = require("fbp-graph");
+const TheGraph = require("../index.js");
+
+const parseFBP = fbpString =>
+  new Promise((resolve, reject) =>
+    fbpGraph.graph.loadFBP(
+      fbpString,
+      (err, graph) =>
+        err instanceof fbpGraph.Graph
+          ? resolve(err)
+          : err ? reject(err) : resolve(graph)
+    )
+  );
+
+const dummyComponent = {
+  inports: [
+    {
+      name: "in",
+      type: "all"
+    }
+  ],
+  outports: [
+    {
+      name: "out",
+      type: "all"
+    }
+  ]
+};
+
+const name = "'42' -> CONFIG foo(Foo) OUT -> IN bar(Bar)";
+const library = { Foo: dummyComponent, Bar: dummyComponent };
+
+const simulate = (
+  node,
+  type,
+  data = {},
+  opts = { bubbles: true, cancelable: true }
+) => node.dispatchEvent(Object.assign(new Event(type, opts), data));
+
+describe("Editor navigation", () => {
+  let mounted, svg, raf;
+
+  beforeEach(async () => {
+    const graph = await parseFBP(name);
+    raf = window.requestAnimationFrame = jest.fn();
+    mounted = mount(TheGraph.App({ graph, library }));
+    svg = mounted.getDOMNode().getElementsByClassName("app-svg")[0];
+  });
+
+  afterEach(() => mounted.unmount());
+
+  describe("dragging on background", () => {
+    it("should pan graph view", () => {
+      const deltaX = 100;
+      const deltaY = 200;
+      expect(mounted.state("x")).toBe(0);
+      expect(mounted.state("y")).toBe(0);
+      simulate(svg, "panstart");
+      simulate(svg, "panmove", { gesture: { deltaX, deltaY } });
+      simulate(svg, "panend");
+      expect(mounted.state("x")).toBe(deltaX);
+      expect(mounted.state("y")).toBe(deltaY);
+    });
+  });
+
+  describe("mouse scrolling up", () => {
+    it("should zoom in", () => {
+      const deltaY = -100;
+      expect(mounted.state("scale")).toBe(1);
+      svg.onwheel = null;
+      simulate(svg, "wheel", { deltaY });
+      expect(raf).toHaveBeenCalledTimes(1);
+      raf.mock.calls[0][0]();
+      expect(mounted.state("scale")).toBe(1.2);
+    });
+  });
+
+  describe("mouse scrolling down", () => {
+    it("should zoom out", () => {
+      const deltaY = 100;
+      expect(mounted.state("scale")).toBe(1);
+      svg.onwheel = null;
+      simulate(svg, "wheel", { deltaY });
+      expect(raf).toHaveBeenCalledTimes(1);
+      raf.mock.calls[0][0]();
+      expect(mounted.state("scale")).toBe(0.8);
+    });
+  });
+
+  describe("multitouch pinch", () => {
+    it("should zoom in/out", () => {
+      expect(mounted.state("scale")).toBe(1);
+      const touches = [
+        { target: svg, identifier: "0", clientX: 0, clientY: 0 },
+        { target: svg, identifier: "1", clientX: 100, clientY: 100 }
+      ];
+      simulate(svg, "touchstart", { touches, changedTouches: touches });
+      touches[1].clientX = 50;
+      simulate(svg, "touchmove", { touches, changedTouches: [touches[1]] });
+      simulate(svg, "touchend", { touches, changedTouches: touches });
+      expect(mounted.state("scale")).toBe(0.7905694150420948);
+      simulate(svg, "touchstart", { touches, changedTouches: touches });
+      touches[1].clientX = 100;
+      simulate(svg, "touchmove", { touches, changedTouches: [touches[1]] });
+      simulate(svg, "touchend", { touches, changedTouches: touches });
+      expect(mounted.state("scale")).toBe(1);
+    });
+  });
+
+  describe("hovering an node", () => {
+    it("should highlight node");
+  });
+  describe("hovering an edge", () => {
+    it("should highlight edge");
+  });
+  describe("hovering exported port", () => {
+    it("should highlight exported port");
+  });
+  describe("hovering node group", () => {
+    it("should highlight the group");
+  });
+});
+
+describe("Editor", () => {
+  let mounted, svg, raf, selectedNodes, selectedEdges;
+
+  beforeEach(async () => {
+    selectedNodes = {};
+    selectedEdges = {};
+    const graph = await parseFBP(name);
+    raf = window.requestAnimationFrame = jest.fn();
+    mounted = mount(
+      TheGraph.App({
+        graph,
+        library,
+        onNodeSelection: (id, node, toggle) => {
+          if (toggle) return (selectedNodes[id] = !selectedNodes[id]);
+          selectedNodes = selectedNodes[id] ? {} : { [id]: true };
+        }
+      })
+    );
+    svg = mounted.getDOMNode().getElementsByClassName("app-svg")[0];
+  });
+
+  afterEach(() => mounted.unmount());
+
+  describe("dragging on node", () => {
+    it("should move the node", () => {
+      const deltaX = 100;
+      const deltaY = 200;
+      expect(mounted.props().graph.nodes[0].metadata.x).toBe(0);
+      expect(mounted.props().graph.nodes[0].metadata.y).toBe(0);
+      const [node] = mounted.getDOMNode().getElementsByClassName("node");
+      simulate(node, "panstart");
+      simulate(node, "panmove", { gesture: { deltaX, deltaY } });
+      simulate(node, "panend");
+      raf.mock.calls.forEach(([c]) => c());
+      expect(mounted.props().graph.nodes[0].metadata.x).toBe(108);
+      expect(mounted.props().graph.nodes[0].metadata.y).toBe(216);
+    });
+  });
+
+  describe("dragging on exported port", () => {
+    it("should move the port");
+  });
+
+  describe("dragging from node port", () => {
+    it("should start making edge", () => {
+      const deltaX = 100;
+      const deltaY = 200;
+      expect(svg.getElementsByClassName("edge")).toHaveLength(1);
+      const [port] = svg.getElementsByClassName("port");
+      simulate(port, "panstart");
+      simulate(port, "panmove", { gesture: { deltaX, deltaY } });
+      raf.mock.calls.forEach(([c]) => c());
+      expect(svg.getElementsByClassName("edge")).toHaveLength(2);
+    });
+  });
+
+  describe("dropping started edge on port", () => {
+    it("should connect the edge", () => {
+      const deltaX = 100;
+      const deltaY = 200;
+      const nodes = [...svg.getElementsByClassName("node")];
+      const [p1, p2] = nodes.map(
+        (n, i) =>
+          n
+            .getElementsByClassName(i ? "outports" : "inports")[0]
+            .getElementsByClassName("port")[0]
+      );
+      simulate(p1, "panstart");
+      simulate(p1, "panmove", { gesture: { deltaX, deltaY } });
+      simulate(p1, "panend");
+      simulate(p2, "tap");
+      raf.mock.calls.forEach(([c]) => c());
+      expect(mounted.props().graph.edges).toHaveLength(2);
+    });
+  });
+
+  describe("dropping started edge outside", () => {
+    it("should not connect the edge", () => {
+      const deltaX = 100;
+      const deltaY = 200;
+      const [p1] = svg
+        .getElementsByClassName("node")[0]
+        .getElementsByClassName("inports")[0]
+        .getElementsByClassName("port");
+      simulate(p1, "panstart");
+      simulate(p1, "panmove", { gesture: { deltaX, deltaY } });
+      simulate(p1, "panend");
+      simulate(svg, "click");
+      raf.mock.calls.forEach(([c]) => c());
+      expect(mounted.props().graph.edges).toHaveLength(1);
+    });
+  });
+
+  describe("clicking exported port", () => {
+    it("does nothing");
+  });
+
+  describe("clicking unselected node", () => {
+    it("should add node to selection", () => {
+      expect(selectedNodes).toEqual({});
+      simulate(svg.getElementsByClassName("node")[0], "tap");
+      raf.mock.calls.forEach(([c]) => c());
+      expect(selectedNodes).toEqual({ foo: true });
+    });
+  });
+
+  describe("clicking selected node", () => {
+    it("should remove node from selection", () => {
+      selectedNodes = { foo: true };
+      simulate(svg.getElementsByClassName("node")[0], "tap");
+      raf.mock.calls.forEach(([c]) => c());
+      expect(selectedNodes).toEqual({});
+    });
+  });
+
+  describe("clicking unselected edge", () => {
+    it("should add edge to selection");
+  });
+  describe("clicking selected edge", () => {
+    it("should remove edge from selection");
+  });
+  describe("selected nodes", () => {
+    it("are visualized with a bounding box");
+    describe("when dragging the box", () => {
+      it("moves all nodes in selection");
+    });
+  });
+  describe("node groups", () => {
+    it("are visualized with a bounding box");
+    it("shows group name");
+    it("shows group description");
+    describe("when dragging on label", () => {
+      it("moves all nodes in group");
+    });
+    describe("when dragging on bounding box", () => {
+      it("does nothing");
+    });
+  });
+  describe("right-click node", () => {
+    it("should open menu for node");
+  });
+  describe("right-click node port", () => {
+    it("should open menu for port");
+  });
+  describe("right-click edge", () => {
+    it("should open menu for edge");
+  });
+  describe("right-click exported port", () => {
+    it("should open menu for exported port");
+  });
+  describe("right-click node group", () => {
+    it("should open menu for group");
+  });
+  describe("right-click background", () => {
+    it("should open menu for editor");
+  });
+  describe("long-press", () => {
+    it("should work same as right-click");
+  });
+});
+
+describe("Editor menus", () => {
+  describe("node menu", () => {
+    it("shows node name");
+    it("shows component icon");
+    it("should have delete action");
+    it("should have copy action");
+    it("should show in and outports");
+    describe("clicking port", () => {
+      it("should start edge");
+    });
+  });
+  describe("node port menu", () => {
+    it("should have export action");
+  });
+  describe("edge menu", () => {
+    it("shows edge name");
+    it("should have delete action");
+  });
+  describe("exported port menu", () => {
+    it("should have delete action");
+  });
+  describe("node selection menu", () => {
+    it("should have group action");
+    it("should have copy action");
+  });
+  describe("editor menu", () => {
+    it("should have paste action");
+  });
+});

--- a/__tests__/graphchanges.js
+++ b/__tests__/graphchanges.js
@@ -1,0 +1,26 @@
+describe("Graph changes", () => {
+  describe("adding node", () => {
+    it("should update editor");
+  });
+  describe("removing node", () => {
+    it("should update editor");
+  });
+  describe("adding edge", () => {
+    it("should update editor");
+  });
+  describe("removing edge", () => {
+    it("should update editor");
+  });
+  describe("adding inport", () => {
+    it("should update editor");
+  });
+  describe("removing inport", () => {
+    it("should update editor");
+  });
+  describe("adding outport", () => {
+    it("should update editor");
+  });
+  describe("removing outport", () => {
+    it("should update editor");
+  });
+});

--- a/__tests__/nav.js
+++ b/__tests__/nav.js
@@ -1,0 +1,6 @@
+describe("Navigation", () => {
+  it("renders a simplified version of graph");
+  it("supports dark & light theme");
+  it("supports specifying nodeSize");
+  it("supports fill,stroke,edge styles");
+});

--- a/__tests__/thumbnail.js
+++ b/__tests__/thumbnail.js
@@ -1,0 +1,6 @@
+describe("Thumbnail", () => {
+  it("renders a thumbnail of graph");
+  it("visualizes the viewport area");
+  it("allows to pan viewport");
+  it("hides when whole graph is in view");
+});

--- a/examples/demo-full.html
+++ b/examples/demo-full.html
@@ -4,15 +4,9 @@
     <title>Graph Editor</title>
     <meta charset="utf-8">
 
-    <!-- Libraries -->
-    <script src="../node_modules/react/dist/react.js"></script>
-    <script src="../node_modules/react-dom/dist/react-dom.js"></script>
-    <script src="../node_modules/klayjs-noflo/klay-noflo.js"></script>
-    <script src="../node_modules/hammerjs/hammer.min.js"></script>
-
     <!-- Browserify Libraries -->
+    <script src="../dist/vendor.js"></script>
     <script src="../dist/the-graph.js"></script>
-    <script src="../node_modules/@pleasetrythisathome/react.animate/react.animate.js"></script>
 
     <link rel="stylesheet" href="../themes/the-graph-dark.css">
     <link rel="stylesheet" href="../themes/the-graph-light.css">

--- a/examples/demo-simple.html
+++ b/examples/demo-simple.html
@@ -4,13 +4,8 @@
     <title>Graph Editor Demo</title>
     <meta charset="utf-8">
 
-    <!-- Libraries -->
-    <script src="../node_modules/react/dist/react.js"></script>
-    <script src="../node_modules/react-dom/dist/react-dom.js"></script>
-    <script src="../node_modules/klayjs-noflo/klay-noflo.js"></script>
-    <script src="../node_modules/hammerjs/hammer.min.js"></script>
-
     <!-- Browserify Libraries -->
+    <script src="../dist/vendor.js"></script>
     <script src="../dist/the-graph.js"></script>
 
     <link rel="stylesheet" href="../themes/the-graph-dark.css">

--- a/examples/demo-thumbnail.html
+++ b/examples/demo-thumbnail.html
@@ -5,8 +5,7 @@
     <meta charset="utf-8">
 
     <!-- Deps -->
-    <script src="../node_modules/react/dist/react.js"></script>
-    <script src="../node_modules/react-dom/dist/react-dom.js"></script>
+    <script src="../dist/vendor.js"></script>
     <script src="../dist/the-graph.js"></script>
 
   </head>

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -1,0 +1,5 @@
+const Enzyme = require("enzyme");
+const Adapter = require("enzyme-adapter-react-15");
+Enzyme.configure({ adapter: new Adapter() });
+document.documentElement.ontouchstart = () => {}
+window.ontouchstart = () => {}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "chai": "^4.0.0",
     "coffee-script": "^1.12.2",
     "coffeeify": "^2.0.1",
+    "enzyme": "^3.2.0",
+    "enzyme-adapter-react-15": "^1.0.5",
     "glob": "^7.0.6",
     "grunt": "~1.0.1",
     "grunt-browserify": "~5.0.0",
@@ -28,9 +30,12 @@
     "grunt-contrib-watch": "~1.0.0",
     "grunt-exec": "~2.0.0",
     "grunt-saucelabs": "^9.0.0",
+    "jest": "^21.2.1",
+    "jest-enzyme": "^4.0.1",
     "mocha": "^3.2.0",
     "react": "^15.6.2",
     "react-dom": "^15.6.2",
+    "react-test-renderer": "^15.6.2",
     "stylus": "~0.54.5"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "main": "index.js",
   "dependencies": {
     "@pleasetrythisathome/react.animate": "0.0.4",
+    "create-react-class": "^15.6.2",
     "ease-component": "^1.0.0",
     "fbp-graph": "^0.1.0",
     "font-awesome": "^4.6.3",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,6 @@
     "font-awesome": "^4.6.3",
     "hammerjs": "^2.0.8",
     "klayjs-noflo": "^0.3.1",
-    "react": "^0.14.3",
-    "react-dom": "^0.14.3",
     "tv4": "^1.3.0"
   },
   "devDependencies": {
@@ -30,6 +28,8 @@
     "grunt-exec": "~2.0.0",
     "grunt-saucelabs": "^9.0.0",
     "mocha": "^3.2.0",
+    "react": "^15.6.2",
+    "react-dom": "^15.6.2",
     "stylus": "~0.54.5"
   },
   "scripts": {
@@ -45,5 +45,9 @@
   },
   "keywords": [
     "graph"
-  ]
+  ],
+  "peerDependencies": {
+    "react": "<16.0.0",
+    "react-dom": "<16.0.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "tv4": "^1.3.0"
   },
   "devDependencies": {
+    "canvas-prebuilt": "^1.6.5-prerelease.1",
     "chai": "^4.0.0",
     "coffee-script": "^1.12.2",
     "coffeeify": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -55,5 +55,16 @@
   "peerDependencies": {
     "react": "<16.0.0",
     "react-dom": "<16.0.0"
+  },
+  "jest": {
+    "coveragePathIgnorePatterns": [
+      "<rootDir>/node_modules/",
+      "<rootDir>/dist/",
+      "<rootDir>/jest-setup.js"
+    ],
+    "setupFiles": [
+      "<rootDir>/jest-setup.js"
+    ],
+    "setupTestFrameworkScriptFile": "jest-enzyme"
   }
 }

--- a/spec/runner.html
+++ b/spec/runner.html
@@ -7,14 +7,12 @@
     <link rel="stylesheet" href="../themes/the-graph-dark.css">
 
     <!-- External dependencies -->
-    <script src="../node_modules/react/dist/react.js"></script>
-    <script src="../node_modules/react-dom/dist/react-dom.js"></script>
     <script src="../node_modules/klayjs-noflo/klay-noflo.js"></script>
     <script src="../node_modules/hammerjs/hammer.min.js"></script>
 
     <!-- Browserify Libraries -->
+    <script src="../dist/vendor.js"></script>
     <script src="../dist/the-graph.js"></script>
-    <script src="../node_modules/@pleasetrythisathome/react.animate/react.animate.js"></script>
 
     <style type="text/css">
       #editor {

--- a/spec/runner.html
+++ b/spec/runner.html
@@ -8,7 +8,6 @@
 
     <!-- External dependencies -->
     <script src="../node_modules/klayjs-noflo/klay-noflo.js"></script>
-    <script src="../node_modules/hammerjs/hammer.min.js"></script>
 
     <!-- Browserify Libraries -->
     <script src="../dist/vendor.js"></script>

--- a/spec/vendor.coffee
+++ b/spec/vendor.coffee
@@ -1,0 +1,2 @@
+window.React = require 'react'
+window.ReactDOM = require 'react-dom'

--- a/the-graph-nav/the-graph-nav.js
+++ b/the-graph-nav/the-graph-nav.js
@@ -1,4 +1,5 @@
 
+var React = require('react');
 var thumb = require('../the-graph-thumb/the-graph-thumb.js');
 
 function calculateStyleFromTheme(theme) {

--- a/the-graph-nav/the-graph-nav.js
+++ b/the-graph-nav/the-graph-nav.js
@@ -183,11 +183,10 @@ var Component = React.createClass({
       },
     };
     // Elements
-    var d = React.DOM;
-    return d.div( { key: 'nav', style: wrapperStyle, ref: this._refTopElement }, [
-      d.div( viewboxDiv ),
-      d.canvas( viewboxCanvas ),
-      d.canvas( thumbProps ),
+    return React.createElement('div', { key: 'nav', style: wrapperStyle, ref: this._refTopElement }, [
+      React.createElement('div', viewboxDiv ),
+      React.createElement('canvas', viewboxCanvas ),
+      React.createElement('canvas', thumbProps ),
     ]);
   },
   componentDidUpdate: function() {

--- a/the-graph-nav/the-graph-nav.js
+++ b/the-graph-nav/the-graph-nav.js
@@ -1,6 +1,7 @@
 
 var React = require('react');
 var createReactClass = require('create-react-class');
+var Hammer = require('hammerjs');
 var thumb = require('../the-graph-thumb/the-graph-thumb.js');
 
 function calculateStyleFromTheme(theme) {

--- a/the-graph-nav/the-graph-nav.js
+++ b/the-graph-nav/the-graph-nav.js
@@ -1,5 +1,6 @@
 
 var React = require('react');
+var createReactClass = require('create-react-class');
 var thumb = require('../the-graph-thumb/the-graph-thumb.js');
 
 function calculateStyleFromTheme(theme) {
@@ -115,7 +116,7 @@ function renderViewboxFromProps(context, viewbox, thumbInfo, props) {
 }
 
 // https://toddmotto.com/react-create-class-versus-component/
-var Component = React.createClass({
+var Component = createReactClass({
   propTypes: {
   },
   getDefaultProps: function() {

--- a/the-graph/factories.js
+++ b/the-graph/factories.js
@@ -1,32 +1,32 @@
 // Standard functions for creating SVG/HTML elements
 exports.createGroup = function(options, content) {
-  var args = [options];
+  var args = ['g', options];
 
   if (Array.isArray(content)) {
     args = args.concat(content);
   }
 
-  return React.DOM.g.apply(React.DOM.g, args);
+  return React.createElement.apply(React, args);
 };
 
 exports.createRect = function(options) {
-  return React.DOM.rect(options);
+  return React.createElement('rect', options);
 };
 
 exports.createText = function(options) {
-  return React.DOM.text(options);
+  return React.createElement('text', options);
 };
 
 exports.createCircle = function(options) {
-  return React.DOM.circle(options);
+  return React.createElement('circle', options);
 };
 
 exports.createPath = function(options) {
-  return React.DOM.path(options);
+  return React.createElement('path', options);
 };
 
 exports.createPolygon = function(options) {
-  return React.DOM.polygon(options);
+  return React.createElement('polygon', options);
 };
 
 exports.createImg = function(options) {
@@ -34,16 +34,16 @@ exports.createImg = function(options) {
 };
 
 exports.createCanvas = function(options) {
-  return React.DOM.canvas(options);
+  return React.createElement('canvas', options);
 };
 
 exports.createSvg = function(options, content) {
 
-  var args = [options];
+  var args = ['svg', options];
 
   if (Array.isArray(content)) {
     args = args.concat(content);
   }
 
-  return React.DOM.svg.apply(React.DOM.svg, args);
+  return React.createElement.apply(React, args);
 };

--- a/the-graph/factories.js
+++ b/the-graph/factories.js
@@ -1,3 +1,4 @@
+var React = require('react');
 // Standard functions for creating SVG/HTML elements
 exports.createGroup = function(options, content) {
   var args = ['g', options];

--- a/the-graph/hammer.js
+++ b/the-graph/hammer.js
@@ -1,3 +1,4 @@
+var Hammer = require('hammerjs');
 // Contains code from hammmer.js
 // https://github.com/hammerjs/hammer.js
 // The MIT License (MIT)

--- a/the-graph/mixins.js
+++ b/the-graph/mixins.js
@@ -23,11 +23,12 @@ var Tooltip = {
     var tooltipEvent = new CustomEvent('the-graph-tooltip-hide', { 
       bubbles: true
     });
-    if (this.isMounted()) {
+    if (this.mounted) {
       ReactDOM.findDOMNode(this).dispatchEvent(tooltipEvent);
     }
   },
   componentDidMount: function () {
+    this.mounted = true;
     if (navigator && navigator.userAgent.indexOf("Firefox") !== -1) {
       // HACK Ff does native tooltips on svg elements
       return;
@@ -36,6 +37,9 @@ var Tooltip = {
     tooltipper.addEventListener("tap", this.showTooltip);
     tooltipper.addEventListener("mouseenter", this.showTooltip);
     tooltipper.addEventListener("mouseleave", this.hideTooltip);
+  },
+  componentWillUnmount: function () {
+    this.mounted = false;
   }
 };
 

--- a/the-graph/mixins.js
+++ b/the-graph/mixins.js
@@ -1,3 +1,4 @@
+var ReactDOM = require('react-dom');
 // React mixins
 
 // Show fake tooltip

--- a/the-graph/the-graph-app.js
+++ b/the-graph/the-graph-app.js
@@ -441,10 +441,10 @@ module.exports.register = function (context) {
       }
 
       // Wheel to zoom
-      if (domNode.onwheel!==undefined) {
+      if ('onwheel' in domNode) {
         // Chrome and Firefox
         domNode.addEventListener("wheel", this.onWheel);
-      } else if (domNode.onmousewheel!==undefined) {
+      } else if ('onmousewheel' in domNode) {
         // Safari
         domNode.addEventListener("mousewheel", this.onWheel);
       }

--- a/the-graph/the-graph-app.js
+++ b/the-graph/the-graph-app.js
@@ -1,3 +1,4 @@
+var React = require('react');
 var ReactDOM = require('react-dom');
 var hammerhacks = require('./hammer.js');
 

--- a/the-graph/the-graph-app.js
+++ b/the-graph/the-graph-app.js
@@ -1,6 +1,7 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
 var createReactClass = require('create-react-class');
+var Hammer = require('hammerjs');
 var hammerhacks = require('./hammer.js');
 
 // Trivial polyfill for Polymer/webcomponents/shadowDOM element unwrapping

--- a/the-graph/the-graph-app.js
+++ b/the-graph/the-graph-app.js
@@ -115,7 +115,7 @@ module.exports.register = function (context) {
   }
 
   var mixins = [];
-  if (window.React.Animate) {
+  if (React.Animate) {
     mixins.push(React.Animate);
   }
 

--- a/the-graph/the-graph-app.js
+++ b/the-graph/the-graph-app.js
@@ -1,5 +1,6 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
+var createReactClass = require('create-react-class');
 var hammerhacks = require('./hammer.js');
 
 // Trivial polyfill for Polymer/webcomponents/shadowDOM element unwrapping
@@ -133,7 +134,7 @@ module.exports.register = function (context) {
     return null;
   }
 
-  TheGraph.App = React.createFactory( React.createClass({
+  TheGraph.App = React.createFactory( createReactClass({
     displayName: "TheGraphApp",
     mixins: mixins,
     getDefaultProps: function() {

--- a/the-graph/the-graph-app.js
+++ b/the-graph/the-graph-app.js
@@ -1,3 +1,4 @@
+var ReactDOM = require('react-dom');
 var hammerhacks = require('./hammer.js');
 
 // Trivial polyfill for Polymer/webcomponents/shadowDOM element unwrapping

--- a/the-graph/the-graph-app.js
+++ b/the-graph/the-graph-app.js
@@ -93,13 +93,13 @@ module.exports.register = function (context) {
 
   // No need to promote DIV creation to TheGraph.js.
   function createAppContainer(options, content) {
-    var args = [options];
+    var args = ['div', options];
 
     if (Array.isArray(content)) {
       args = args.concat(content);
     }
 
-    return React.DOM.div.apply(React.DOM.div, args);
+    return React.createElement.apply(React, args);
   }
 
   function createAppGraph(options) {

--- a/the-graph/the-graph-edge.js
+++ b/the-graph/the-graph-edge.js
@@ -1,3 +1,4 @@
+var ReactDOM = require('react-dom');
 var TooltipMixin = require('./mixins').Tooltip;
 
 module.exports.register = function (context) {

--- a/the-graph/the-graph-edge.js
+++ b/the-graph/the-graph-edge.js
@@ -1,5 +1,6 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
+var createReactClass = require('create-react-class');
 var TooltipMixin = require('./mixins').Tooltip;
 
 module.exports.register = function (context) {
@@ -73,7 +74,7 @@ module.exports.register = function (context) {
 
   // Edge view
 
-  TheGraph.Edge = React.createFactory( React.createClass({
+  TheGraph.Edge = React.createFactory( createReactClass({
     displayName: "TheGraphEdge",
     mixins: [
       TooltipMixin

--- a/the-graph/the-graph-edge.js
+++ b/the-graph/the-graph-edge.js
@@ -1,3 +1,4 @@
+var React = require('react');
 var ReactDOM = require('react-dom');
 var TooltipMixin = require('./mixins').Tooltip;
 

--- a/the-graph/the-graph-graph.js
+++ b/the-graph/the-graph-graph.js
@@ -1,5 +1,6 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
+var createReactClass = require('create-react-class');
 
 module.exports.register = function (context) {
 
@@ -82,7 +83,7 @@ module.exports.register = function (context) {
 
   // Graph view
 
-  TheGraph.Graph = React.createFactory( React.createClass({
+  TheGraph.Graph = React.createFactory( createReactClass({
     displayName: "TheGraphGraph",
     mixins: [],
     getDefaultProps: function () {

--- a/the-graph/the-graph-graph.js
+++ b/the-graph/the-graph-graph.js
@@ -1,3 +1,5 @@
+var ReactDOM = require('react-dom');
+
 module.exports.register = function (context) {
 
   var TheGraph = context.TheGraph;

--- a/the-graph/the-graph-graph.js
+++ b/the-graph/the-graph-graph.js
@@ -1,3 +1,4 @@
+var React = require('react');
 var ReactDOM = require('react-dom');
 
 module.exports.register = function (context) {

--- a/the-graph/the-graph-graph.js
+++ b/the-graph/the-graph-graph.js
@@ -111,8 +111,12 @@ module.exports.register = function (context) {
       };
     },
     componentDidMount: function () {
+        this.mounted = true;
         this.subscribeGraph(null, this.props.graph);
         ReactDOM.findDOMNode(this).addEventListener("the-graph-node-remove", this.removeNode);
+    },
+    componentWillUnmount: function () {
+        this.mounted = false;
     },
     componentWillReceiveProps: function(nextProps) {
       this.subscribeGraph(this.props.graph, nextProps.graph);
@@ -421,7 +425,7 @@ module.exports.register = function (context) {
       window.requestAnimationFrame(this.triggerRender);
     },
     triggerRender: function (time) {
-      if (!this.isMounted()) {
+      if (!this.mounted) {
         return;
       }
       if (this.dirty) {

--- a/the-graph/the-graph-group.js
+++ b/the-graph/the-graph-group.js
@@ -1,3 +1,5 @@
+var ReactDOM = require('react-dom');
+
 module.exports.register = function (context) {
 
   var TheGraph = context.TheGraph;

--- a/the-graph/the-graph-group.js
+++ b/the-graph/the-graph-group.js
@@ -1,5 +1,6 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
+var createReactClass = require('create-react-class');
 
 module.exports.register = function (context) {
 
@@ -30,7 +31,7 @@ module.exports.register = function (context) {
 
   // Group view
 
-  TheGraph.Group = React.createFactory( React.createClass({
+  TheGraph.Group = React.createFactory( createReactClass({
     displayName: "TheGraphGroup",
     getInitialState: function () {
         return {

--- a/the-graph/the-graph-group.js
+++ b/the-graph/the-graph-group.js
@@ -1,3 +1,4 @@
+var React = require('react');
 var ReactDOM = require('react-dom');
 
 module.exports.register = function (context) {

--- a/the-graph/the-graph-iip.js
+++ b/the-graph/the-graph-iip.js
@@ -1,4 +1,5 @@
 var React = require('react');
+var createReactClass = require('create-react-class');
 
 module.exports.register = function (context) {
 
@@ -34,7 +35,7 @@ module.exports.register = function (context) {
 
   // Edge view
 
-  TheGraph.IIP = React.createFactory( React.createClass({
+  TheGraph.IIP = React.createFactory( createReactClass({
     displayName: "TheGraphIIP",
     shouldComponentUpdate: function (nextProps, nextState) {
       // Only rerender if changed

--- a/the-graph/the-graph-iip.js
+++ b/the-graph/the-graph-iip.js
@@ -1,3 +1,5 @@
+var React = require('react');
+
 module.exports.register = function (context) {
 
   var TheGraph = context.TheGraph;

--- a/the-graph/the-graph-menu.js
+++ b/the-graph/the-graph-menu.js
@@ -1,5 +1,6 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
+var createReactClass = require('create-react-class');
 var arcs = require('./arcs');
 
 module.exports.register = function (context) {
@@ -125,7 +126,7 @@ module.exports.register = function (context) {
     return TheGraph.factories.menu.createMenuGroup.call(this, containerOptions);
   }
 
-  TheGraph.Menu = React.createFactory( React.createClass({
+  TheGraph.Menu = React.createFactory( createReactClass({
     displayName: "TheGraphMenu",
     radius: TheGraph.config.menu.radius,
     getInitialState: function() {
@@ -261,7 +262,7 @@ module.exports.register = function (context) {
   };
 
 
-  TheGraph.ModalBG = React.createFactory( React.createClass({
+  TheGraph.ModalBG = React.createFactory( createReactClass({
     displayName: "TheGraphModalBG",
     componentDidMount: function () {
       var domNode = ReactDOM.findDOMNode(this);

--- a/the-graph/the-graph-menu.js
+++ b/the-graph/the-graph-menu.js
@@ -1,3 +1,4 @@
+var React = require('react');
 var ReactDOM = require('react-dom');
 var arcs = require('./arcs');
 

--- a/the-graph/the-graph-menu.js
+++ b/the-graph/the-graph-menu.js
@@ -1,3 +1,4 @@
+var ReactDOM = require('react-dom');
 var arcs = require('./arcs');
 
 module.exports.register = function (context) {

--- a/the-graph/the-graph-node-menu-port.js
+++ b/the-graph/the-graph-node-menu-port.js
@@ -1,3 +1,5 @@
+var ReactDOM = require('react-dom');
+
 module.exports.register = function (context) {
 
   var TheGraph = context.TheGraph;

--- a/the-graph/the-graph-node-menu-port.js
+++ b/the-graph/the-graph-node-menu-port.js
@@ -1,3 +1,4 @@
+var React = require('react');
 var ReactDOM = require('react-dom');
 
 module.exports.register = function (context) {

--- a/the-graph/the-graph-node-menu-port.js
+++ b/the-graph/the-graph-node-menu-port.js
@@ -1,5 +1,6 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
+var createReactClass = require('create-react-class');
 
 module.exports.register = function (context) {
 
@@ -26,7 +27,7 @@ module.exports.register = function (context) {
   };
 
 
-  TheGraph.NodeMenuPort = React.createFactory( React.createClass({
+  TheGraph.NodeMenuPort = React.createFactory( createReactClass({
     displayName: "TheGraphNodeMenuPort",
     componentDidMount: function () {
       ReactDOM.findDOMNode(this).addEventListener("tap", this.edgeStart);

--- a/the-graph/the-graph-node-menu-ports.js
+++ b/the-graph/the-graph-node-menu-ports.js
@@ -1,3 +1,5 @@
+var React = require('react');
+
 module.exports.register = function (context) {
 
   var TheGraph = context.TheGraph;

--- a/the-graph/the-graph-node-menu-ports.js
+++ b/the-graph/the-graph-node-menu-ports.js
@@ -1,4 +1,5 @@
 var React = require('react');
+var createReactClass = require('create-react-class');
 
 module.exports.register = function (context) {
 
@@ -30,7 +31,7 @@ module.exports.register = function (context) {
     return TheGraph.NodeMenuPort(options);
   }
 
-  TheGraph.NodeMenuPorts = React.createFactory( React.createClass({
+  TheGraph.NodeMenuPorts = React.createFactory( createReactClass({
     displayName: "TheGraphNodeMenuPorts",
     render: function() {
       var portViews = [];

--- a/the-graph/the-graph-node-menu.js
+++ b/the-graph/the-graph-node-menu.js
@@ -1,3 +1,5 @@
+var ReactDOM = require('react-dom');
+
 module.exports.register = function (context) {
 
   var TheGraph = context.TheGraph;

--- a/the-graph/the-graph-node-menu.js
+++ b/the-graph/the-graph-node-menu.js
@@ -1,3 +1,4 @@
+var React = require('react');
 var ReactDOM = require('react-dom');
 
 module.exports.register = function (context) {

--- a/the-graph/the-graph-node-menu.js
+++ b/the-graph/the-graph-node-menu.js
@@ -1,5 +1,6 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
+var createReactClass = require('create-react-class');
 
 module.exports.register = function (context) {
 
@@ -32,7 +33,7 @@ module.exports.register = function (context) {
     return TheGraph.Menu(options);
   }
 
-  TheGraph.NodeMenu = React.createFactory( React.createClass({
+  TheGraph.NodeMenu = React.createFactory( createReactClass({
     displayName: "TheGraphNodeMenu",
     radius: 72,
     stopPropagation: function (event) {

--- a/the-graph/the-graph-node.js
+++ b/the-graph/the-graph-node.js
@@ -1,3 +1,4 @@
+var ReactDOM = require('react-dom');
 var TooltipMixin = require('./mixins').Tooltip;
 
 module.exports.register = function (context) {

--- a/the-graph/the-graph-node.js
+++ b/the-graph/the-graph-node.js
@@ -1,5 +1,6 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
+var createReactClass = require('create-react-class');
 var TooltipMixin = require('./mixins').Tooltip;
 
 module.exports.register = function (context) {
@@ -84,7 +85,7 @@ module.exports.register = function (context) {
   }
 
   // Node view
-  TheGraph.Node = React.createFactory( React.createClass({
+  TheGraph.Node = React.createFactory( createReactClass({
     displayName: "TheGraphNode",
     mixins: [
       TooltipMixin

--- a/the-graph/the-graph-node.js
+++ b/the-graph/the-graph-node.js
@@ -1,3 +1,4 @@
+var React = require('react');
 var ReactDOM = require('react-dom');
 var TooltipMixin = require('./mixins').Tooltip;
 

--- a/the-graph/the-graph-port.js
+++ b/the-graph/the-graph-port.js
@@ -1,5 +1,6 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
+var createReactClass = require('create-react-class');
 var TooltipMixin = require('./mixins').Tooltip;
 var arcs = require('./arcs.js');
 
@@ -37,7 +38,7 @@ module.exports.register = function (context) {
 
   // Port view
 
-  TheGraph.Port = React.createFactory( React.createClass({
+  TheGraph.Port = React.createFactory( createReactClass({
     displayName: "TheGraphPort",
     mixins: [
       TooltipMixin

--- a/the-graph/the-graph-port.js
+++ b/the-graph/the-graph-port.js
@@ -1,3 +1,4 @@
+var React = require('react');
 var ReactDOM = require('react-dom');
 var TooltipMixin = require('./mixins').Tooltip;
 var arcs = require('./arcs.js');

--- a/the-graph/the-graph-port.js
+++ b/the-graph/the-graph-port.js
@@ -1,3 +1,4 @@
+var ReactDOM = require('react-dom');
 var TooltipMixin = require('./mixins').Tooltip;
 var arcs = require('./arcs.js');
 

--- a/the-graph/the-graph-tooltip.js
+++ b/the-graph/the-graph-tooltip.js
@@ -1,3 +1,4 @@
+var React = require('react');
 var defaultFactories = require('./factories.js');
 var merge = require('./merge.js');
 

--- a/the-graph/the-graph-tooltip.js
+++ b/the-graph/the-graph-tooltip.js
@@ -1,4 +1,5 @@
 var React = require('react');
+var createReactClass = require('create-react-class');
 var defaultFactories = require('./factories.js');
 var merge = require('./merge.js');
 
@@ -26,7 +27,7 @@ var factories = {
 };
 
 // Port view
-var Tooltip = React.createFactory( React.createClass({
+var Tooltip = React.createFactory( createReactClass({
   displayName: "TheGraphTooltip",
   render: function() {
 

--- a/the-graph/the-graph.js
+++ b/the-graph/the-graph.js
@@ -225,7 +225,7 @@ module.exports.register = function (context) {
         html = html +'height="' + this.props.height + '"';
         html = html +'/>';
 
-        return React.DOM.g({
+        return React.createElement('g', {
             className: this.props.className,
             dangerouslySetInnerHTML:{__html: html}
         });
@@ -257,11 +257,12 @@ module.exports.register = function (context) {
         textAnchor = "end";
       }
 
-      return React.DOM.g(
+      return React.createElement(
+        'g',
         {
           className: (this.props.className ? this.props.className : "text-bg"),
         },
-        React.DOM.rect({
+        React.createElement('rect', {
           className: "text-bg-rect",
           x: x,
           y: y,
@@ -270,7 +271,7 @@ module.exports.register = function (context) {
           height: height * 1.1,
           width: width
         }),
-        React.DOM.text({
+        React.createElement('text', {
           className: (this.props.textClassName ? this.props.textClassName : "text-bg-text"),
           x: this.props.x,
           y: this.props.y,

--- a/the-graph/the-graph.js
+++ b/the-graph/the-graph.js
@@ -1,4 +1,5 @@
 var React = require('react');
+var createReactClass = require('create-react-class');
 
 module.exports.register = function (context) {
 
@@ -216,7 +217,7 @@ module.exports.register = function (context) {
   };
 
   // Reusable React classes
-  TheGraph.SVGImage = React.createFactory( React.createClass({
+  TheGraph.SVGImage = React.createFactory( createReactClass({
     displayName: "TheGraphSVGImage",
     render: function() {
         var html = '<image ';
@@ -234,7 +235,7 @@ module.exports.register = function (context) {
     }
   }));
 
-  TheGraph.TextBG = React.createFactory( React.createClass({
+  TheGraph.TextBG = React.createFactory( createReactClass({
     displayName: "TheGraphTextBG",
     render: function() {
       var text = this.props.text;

--- a/the-graph/the-graph.js
+++ b/the-graph/the-graph.js
@@ -1,3 +1,5 @@
+var React = require('react');
+
 module.exports.register = function (context) {
 
   var defaultNodeSize = 72;


### PR DESCRIPTION
I read thru @jonnor's [comment](https://github.com/flowhub/the-graph/issues/360#issuecomment-347663223) and wanted to get the ball rolling on tests that would make a react upgrade feasible. This PR does the minimum required to allow use in strictly-cjs environments (webpack) and upgrade to react-15 with no deprecation warnings. I copied the existing tests from `spec` and began filling them out for jest. If this is the wrong approach, please let me know. Otherwise I'm going to continue adding tests, focussing on maximizing coverage. I did *not* replace the mocha runner with jest yet, so CI and `npm test` still run the old tests for now.