### PR TITLE
fix 'TheGraph undefined' error when using SVG images

### DIFF
--- a/the-graph/factories.js
+++ b/the-graph/factories.js
@@ -34,7 +34,7 @@ exports.createPolygon = function(options) {
 };
 
 exports.createImg = function(options) {
-  return TheGraph.SVGImage(options);
+  return SVGImage(options);
 };
 
 exports.createCanvas = function(options) {


### PR DESCRIPTION
The graph crashes when using 'iconsvg' option on nodes.
Current wrokaround is:
```
const TheGraph = require('the-graph/dist/the-graph');
TheGraph.factories.node.createNodeIconSVG = TheGraph.SVGImage;
```