### PR TITLE
Fix react warning: Setting defaultProps as an instance property on Co…

### DIFF
--- a/the-graph/the-graph-port.js
+++ b/the-graph/the-graph-port.js
@@ -43,9 +43,6 @@ module.exports.register = function (context) {
     mixins: [
       TooltipMixin
     ],
-    defaultProps: {
-      allowEdgeStart: true,
-    },
     componentDidMount: function () {
       var domNode = ReactDOM.findDOMNode(this);
 
@@ -206,5 +203,8 @@ module.exports.register = function (context) {
     }
   }));
 
+  TheGraph.Port.defaultProps = {
+    allowEdgeStart: true,
+  };
 
 };


### PR DESCRIPTION
This warning is very annoying with React16: `warning: Setting defaultProps as an instance property on Component is not supported and will be ignored. Instead, define defaultProps as a static property on Component.`