### PR TITLE
fix call to SVGImage

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 ## dev
 
+## 0.12.0 (2018 February 19)
+
+New features
+
+* `the-graph-render`: CLI tool for a graph to PNG/JPEG/SVG output.
+This is especially useful for generating images for documentation purposes.
+Implemented by executing the-graph codebase in a browser using JsJob.
+Some of the rendering API is available experimentally under `TheGraph.render`, or one can execute the .jsjob programatically in Node.js.
+
 ## 0.11.1 (2017 December 27)
 
 Bugfixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-graph",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "flow-based programming graph editing",
   "author": "Forrest Oliphant, the Grid",
   "license": "MIT",


### PR DESCRIPTION
Fixes the following error: 

Uncaught ReferenceError: TheGraph is not defined
    at Object.push../node_modules/the-graph/the-graph/factories.js.exports.createImg (factories.js:37)
    at Object.render (the-graph-node.js:460)
    at finishClassComponent (react-dom.development.js:14301)
    at updateClassComponent (react-dom.development.js:14264)
    at beginWork (react-dom.development.js:15082)
    at performUnitOfWork (react-dom.development.js:17820)
    at workLoop (react-dom.development.js:17860)
    at renderRoot (react-dom.development.js:17946)
    at performWorkOnRoot (react-dom.development.js:18837)
    at performWork (react-dom.development.js:18749)
    at performSyncWork (react-dom.development.js:18723)
    at requestWork (react-dom.development.js:18592)
    at scheduleWork (react-dom.development.js:18401)
    at Object.enqueueForceUpdate (react-dom.development.js:12352)
    at Object.Component.forceUpdate (react.development.js:390)
    at setInProps (backend.js:10103)
    at Agent._setProps (backend.js:534)
    at backend.js:7619
    at Array.forEach (<anonymous>)
    at backend.js:7618
    at Array.forEach (<anonymous>)
    at Bridge._handleMessage (backend.js:7611)
    at listener (backend.js:92)
