### PR TITLE
Add support to disable hotkeys

### DIFF
--- a/the-graph/the-graph-app.js
+++ b/the-graph/the-graph-app.js
@@ -162,6 +162,7 @@ module.exports.register = function (context) {
         offsetX: 0.0,
         offsetY: 0.0,
         menus: null,
+        disableHotKeys: null,
         getMenuDef: null,
         onPanScale: null,
         onNodeSelection: null,
@@ -522,7 +523,7 @@ module.exports.register = function (context) {
 
       var code = event.keyCode;
       var handler = hotKeys[code];
-      if (handler) {
+      if (handler && !this.props.disableHotKeys) {
         var readonly = this.props.readonly;
         if (!readonly || (readonly && readOnlyActions[code])) {
           handler(this);
@@ -651,6 +652,7 @@ module.exports.register = function (context) {
         nodeIcons: this.props.nodeIcons,
         onNodeSelection: this.props.onNodeSelection,
         onEdgeSelection: this.props.onEdgeSelection,
+        disableHotKeys: this.props.disableHotKeys,
         showContext: this.showContext,
         allowEdgeStart: !this.props.readonly,
       };


### PR DESCRIPTION
With this change, you can pass `{ disableHotKeys:true}` in as a prop, to turn off the hot key support.