### PR TITLE
Build error with canvas-prebuilt

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "devDependencies": {
     "bluebird": "^3.5.1",
     "browserify-css": "^0.14.0",
-    "canvas-prebuilt": "^1.6.5-prerelease.1",
     "chai": "^4.1.2",
     "coffee-script": "^1.12.2",
     "coffeeify": "^2.0.1",
@@ -40,6 +39,7 @@
     "jest-enzyme": "^4.0.1",
     "jsjob": "^0.10.13",
     "mocha": "^4.1.0",
+    "noflo-canvas": "0.4.2",
     "react": "^15.6.2",
     "react-dom": "^15.6.2",
     "react-test-renderer": "^15.6.2",

--- a/the-graph/the-graph-app.js
+++ b/the-graph/the-graph-app.js
@@ -545,10 +545,13 @@ module.exports.register = function (context) {
       this.refs.graph.markDirty();
     },
     componentDidUpdate: function (prevProps, prevState) {
-      this.renderCanvas(this.bgContext);
-      if (!prevState || prevState.x!==this.state.x || prevState.y!==this.state.y || prevState.scale!==this.state.scale) {
-        this.onPanScale();
-      }
+      setTimeout(function () {
+        this.renderCanvas(this.bgContext);
+        if (!prevState || prevState.x!==this.state.x || prevState.y!==this.state.y || prevState.scale!==this.state.scale) {
+          this.onPanScale();
+        }
+      }, 0);
+
     },
     renderCanvas: function (c) {
       // Comment this line to go plaid


### PR DESCRIPTION
Personally, I hate timeouts to get unit tests to run.  However, it seems like there is a timing issue when looking in the debugger after upgrading the canvas library.  Without this, your canvas objects come back as null in several cases.  Anyways this should resolve the build issue with canvas-prebuilt.

Fixes #391 
Fixes #392 